### PR TITLE
Feature/memtests

### DIFF
--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -136,7 +136,7 @@ public:
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_INFO, "valhalla", "%s", message.c_str());
+    __android_log_print(ANDROID_LOG_INFO, "valhalla", "%s%s", custom_directive.c_str(), message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);
@@ -165,7 +165,7 @@ class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_ERROR, "valhalla", "%s", message.c_str());
+    __android_log_print(ANDROID_LOG_ERROR, "valhalla", "%s%s", custom_directive.c_str(), message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -808,8 +808,8 @@ protected:
   // Array of edge elevation sample sizes
   const uint16_t* edge_elevation_sample_sizes_ = nullptr;
 
-  // Pointers to the edge elevation samples
-  std::vector<const char*> edge_elevation_samples_;
+  // Pointer to start of elevation samples
+  const char* elevation_ptr_ = nullptr;
 
   // Number of bytes in lane connectivity data.
   std::size_t lane_connectivity_size_{};


### PR DESCRIPTION
I did away with the vector of elevation sample pointers. On very dense tiles, this could end up being a large allocation. Now the pointer is computed when needed.

Also fixes a warning when building on Android